### PR TITLE
feat: add searchable book/barcode selects to manual fine creation

### DIFF
--- a/backend/src/api/fine/fine.validation.ts
+++ b/backend/src/api/fine/fine.validation.ts
@@ -30,7 +30,7 @@ export const createManualFineSchema = z.object({
     amount: z.coerce.number().min(0),
     reason: z
       .string()
-      .min(10, "Sabab kamida 10 ta belgidan iborat bo'lishi kerak"),
+      .min(3, "Sabab kamida 3 ta belgidan iborat bo'lishi kerak"),
   }),
 });
 


### PR DESCRIPTION
- Replace text input with searchable book autocomplete
- Add cascading barcode selector with available copies
- Show recent books on dropdown open
- Display copy count and context-aware messages
- Reduce reason validation from 10 to 3 chars

Improves UX and reduces input errors when creating manual fines.