### PR TITLE
fix: Add production API URL for frontend build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,8 @@ jobs:
         run: npm ci
 
       - name: Qurish
+        env:
+          VITE_API_URL: https://api.library.manabi.uz/api/v1
         run: npm run build
 
       - name: AWS hisob ma'lumotlarini sozlash

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=https://api.library.manabi.uz/api/v1

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -14,6 +14,8 @@ dist-ssr
 
 ##
 .env
+.env.local
+!.env.production
 public
 
 # Editor directories and files


### PR DESCRIPTION
## Problem
The frontend was built without the correct `VITE_API_URL` environment variable, causing API calls to fail because they were using relative URLs instead of the full API endpoint.

## Root Cause
- Backend API is at `https://api.library.manabi.uz/api/v1/*`
- Frontend was making calls to `/notifications`, `/dashboard/stats`, etc.
- CloudFront/S3 returns `index.html` for these paths (SPA fallback), causing HTML instead of JSON responses

## Solution
1. Created `.env.production` with correct API URL
2. Updated GitHub Actions workflow to explicitly set `VITE_API_URL` during build
3. Modified `.gitignore` to allow `.env.production` to be committed

## Testing
After merge, the CI/CD pipeline will:
- Build frontend with correct API URL
- Deploy to S3
- Invalidate CloudFront cache
- API calls will work correctly