### PR TITLE
fix: Configure Socket.IO to use production API endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Qurish
         env:
           VITE_API_URL: https://api.library.manabi.uz/api/v1
+          VITE_SOCKET_URL: https://api.library.manabi.uz
         run: npm run build
 
       - name: AWS hisob ma'lumotlarini sozlash

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,2 @@
 VITE_API_URL=https://api.library.manabi.uz/api/v1
+VITE_SOCKET_URL=https://api.library.manabi.uz


### PR DESCRIPTION
## Problem
Socket.IO is attempting to connect to `library.manabi.uz` instead of `api.library.manabi.uz`, causing connection errors:
```
🔥 Socket connection error: server error
```

## Root Cause
- The `VITE_SOCKET_URL` environment variable was not set for production builds
- Frontend defaults to connecting to the same domain as the frontend (CloudFront/S3)
- Socket.IO server is actually running on the backend at `api.library.manabi.uz`

## Solution
1. Added `VITE_SOCKET_URL=https://api.library.manabi.uz` to `.env.production`
2. Updated GitHub Actions workflow to include Socket.IO URL during build

## Testing
After merge and deployment:
- Socket.IO will connect to the correct backend endpoint
- Real-time features (notifications, post comments/reactions) will work
- No more connection errors in console

## Related
Follows up on #34 which fixed the REST API endpoint configuration.