### PR TITLE
fix: Use 'docker compose' instead of 'docker-compose'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,6 +113,6 @@ jobs:
           script: |
             cd ~/backend
             echo "Backend xizmatlari qayta ishga tushirilmoqda..."
-            sudo docker-compose -f docker-compose.prod.yml up -d --build --force-recreate
+            sudo docker compose -f docker-compose.prod.yml up -d --build --force-recreate
             echo "Eski Docker image'lar tozalanmoqda..."
             sudo docker image prune -a -f


### PR DESCRIPTION
## Problem
Backend deployments have been **silently failing** since the penalty check feature was added. The Docker containers on EC2 are running old code from October 22.

## Root Cause
The GitHub Actions workflow uses `docker-compose` (with hyphen), but the EC2 instance has the newer Docker version which uses `docker compose` (without hyphen).

Error from logs:
```
sudo: docker-compose: command not found
```

This caused all backend deployments to fail silently, so the penalty checking feature (#33) never actually deployed.

## Solution
Changed `docker-compose` to `docker compose` in the deployment workflow.

## Impact
After this PR is merged, the backend will **finally deploy properly** with:
- ✅ Penalty checking before loan creation  
- ✅ All other recent backend changes since October

## Testing
The workflow will rebuild and restart the Docker containers on EC2.