### PR TITLE
feat: Use ECR for Docker image deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,30 @@ jobs:
       - name: Kodni yuklab olish
         uses: actions/checkout@v3
 
+      - name: AWS hisob ma'lumotlarini sozlash
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: ECR'ga login qilish
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Docker image qurish va ECR'ga push qilish
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: library-backend
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          cd backend
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+                       -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          echo "IMAGE_URI=$ECR_REGISTRY/$ECR_REPOSITORY:latest" >> $GITHUB_OUTPUT
+
       - name: SSH kalitini sozlash
         uses: webfactory/ssh-agent@v0.5.3
         with:
@@ -98,9 +122,9 @@ jobs:
       - name: .env faylini yaratish
         run: echo "${{ secrets.ENV_FILE_PRODUCTION }}" > ./backend/.env
 
-      - name: Fayllarni EC2'ga rsync orqali deploy qilish
+      - name: Fayllarni EC2'ga rsync orqali deploy qilish (faqat config fayllar)
         run: |
-          rsync -avz --delete --exclude 'node_modules' --exclude 'dist' --exclude '.git' \
+          rsync -avz --delete --exclude 'node_modules' --exclude 'dist' --exclude '.git' --exclude 'src' \
           -e "ssh -o StrictHostKeyChecking=no" \
           ./backend/ ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:~/backend/
 
@@ -112,7 +136,10 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             cd ~/backend
+            echo "ECR'ga login qilinmoqda..."
+            aws ecr get-login-password --region ap-northeast-1 | sudo docker login --username AWS --password-stdin 908027374428.dkr.ecr.ap-northeast-1.amazonaws.com
             echo "Backend xizmatlari qayta ishga tushirilmoqda..."
-            sudo docker compose -f docker-compose.prod.yml up -d --build --force-recreate
+            sudo docker compose -f docker-compose.prod.yml pull
+            sudo docker compose -f docker-compose.prod.yml up -d --force-recreate
             echo "Eski Docker image'lar tozalanmoqda..."
             sudo docker image prune -a -f

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -22,9 +22,7 @@ services:
       - redis_data_prod:/data
 
   api:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: 908027374428.dkr.ecr.ap-northeast-1.amazonaws.com/library-backend:latest
     container_name: library_api_prod
     restart: always
     ports:


### PR DESCRIPTION
Problem: EC2 has only 957MB RAM, insufficient for building Docker images. TypeScript compilation hangs.

Solution: Build in GitHub Actions and push to ECR. EC2 pulls pre-built images.

Benefits:
- Faster deployments
- Lower EC2 resource usage  
- No build timeouts
- Backend updates will deploy properly
- Free with ECR tier