### PR TITLE
chore: Trigger ECR rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ SMTP_PASS=
 
 ## Contributing
 - Use clear, imperative commit messages (e.g., `feat: add reservation status filter`).
+


### PR DESCRIPTION
This triggers a rebuild of the Docker image with the penalty check code that was merged in PR #33.