### PR TITLE
feat: Add return book button to user loans page

### DIFF
--- a/frontend/src/pages/MyLoansPage.tsx
+++ b/frontend/src/pages/MyLoansPage.tsx
@@ -49,6 +49,17 @@ const MyLoansPage: React.FC = () => {
     }
   };
 
+  const handleInitiateReturn = async (loanId: string) => {
+    try {
+      await api.post(`/loans/${loanId}/return`);
+      toast.success('Kitobni qaytarish so`rovi yuborildi! Kutubxonachi tasdiqlaganda kitob qaytariladi.');
+      fetchLoans();
+    } catch (error: any) {
+      const message = error.response?.data?.message || "So'rov yuborishda xatolik yuz berdi.";
+      toast.error(message);
+    }
+  };
+
   if (loading) return <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress /></Box>;
   if (error) return <Alert severity="error">{error}</Alert>;
 
@@ -96,14 +107,27 @@ const MyLoansPage: React.FC = () => {
                     <TableCell data-label="Statusi">{getStatusChip(loan.status)}</TableCell>
                     <TableCell data-label="Harakatlar" align="right">
                       {loan.status === 'ACTIVE' && (
-                        <Button 
-                          size="small" 
-                          variant="outlined"
-                          onClick={() => handleRenewalRequest(loan.id)}
-                          disabled={loan.renewalRequested}
-                        >
-                          {loan.renewalRequested ? 'So`rov Yuborilgan' : 'Muddatni Uzaytirish'}
-                        </Button>
+                        <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+                          <Button 
+                            size="small" 
+                            variant="outlined"
+                            onClick={() => handleRenewalRequest(loan.id)}
+                            disabled={loan.renewalRequested}
+                          >
+                            {loan.renewalRequested ? 'So`rov Yuborilgan' : 'Muddatni Uzaytirish'}
+                          </Button>
+                          <Button 
+                            size="small" 
+                            variant="contained"
+                            color="success"
+                            onClick={() => handleInitiateReturn(loan.id)}
+                          >
+                            Qaytarish
+                          </Button>
+                        </Box>
+                      )}
+                      {loan.status === 'PENDING_RETURN' && (
+                        <Chip label="Qaytarish Kutilmoqda" color="warning" size="small" />
                       )}
                     </TableCell>
                   </TableRow>


### PR DESCRIPTION
## Problem
Users had no way to initiate the book return process from the frontend. The backend API (`POST /loans/:id/return`) existed but was never called from the UI.

This meant the "Qaytarish Kutilyapti" (Pending Return) tab was always empty because users couldn't trigger the return flow.

## Solution
Added a **"Qaytarish" (Return)** button to the user's loans page (`MyLoansPage.tsx`):

### Changes:
1. ✅ Added `handleInitiateReturn` function that calls `POST /loans/:id/return`
2. ✅ Added green "Qaytarish" button next to renewal request button for active loans
3. ✅ Shows "Qaytarish Kutilmoqda" chip when loan status is `PENDING_RETURN`
4. ✅ Success toast notification when return is initiated

### User Flow:
1. User clicks **"Qaytarish"** button on their active loan
2. Loan status changes to `PENDING_RETURN`
3. Book copy status changes to `MAINTENANCE`
4. Loan appears in librarian's **"Qaytarish Kutilyapti"** tab
5. Librarian confirms the return
6. Loan status changes to `RETURNED`

## Testing
- ✅ Verified API endpoint exists and works
- ✅ Checked backend logic in `loan.service.ts`
- ✅ Frontend displays buttons correctly

## Screenshots
Will update after merge if needed.

---
Fixes the missing return initiation flow that was causing confusion about the "Qaytarish Kutilyapti" tab.