### PR TITLE
fix: Add proper cache-control headers to S3 deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,18 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: S3'ga deploy qilish
-        run: aws s3 sync ./dist/ s3://${{ secrets.S3_BUCKET_NAME }}/ --delete
+        run: |
+          # Sync HTML files with no-cache to ensure fresh content
+          aws s3 sync ./dist/ s3://${{ secrets.S3_BUCKET_NAME }}/ \
+            --exclude "*" --include "*.html" \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --delete
+          
+          # Sync JS/CSS with longer cache but versioned filenames
+          aws s3 sync ./dist/ s3://${{ secrets.S3_BUCKET_NAME }}/ \
+            --exclude "*.html" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --delete
 
       - name: CloudFront keshini tozalash
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
## Problem
Your white flash fix was deployed successfully, but AWS wasn't serving the updated files due to missing cache-control headers.

## Root Cause
The `aws s3 sync` command didn't set cache-control headers, causing:
- CloudFront to cache files with default settings
- Browsers to aggressively cache HTML/CSS/JS files
- Users not seeing the latest changes even after CloudFront invalidation

## Solution
Added proper cache-control headers to S3 deployment:
- **HTML files**: `no-cache, no-store, must-revalidate` - ensures users always get fresh content
- **JS/CSS assets**: `public, max-age=31536000, immutable` - safe to cache long-term since Vite adds content hashes to filenames

## Testing
After merge, the white flash fix should be immediately visible to all users without hard refresh.