### PR TITLE
ci: fix rsync path for .deploy.env on EC2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,8 +140,8 @@ jobs:
           rsync -avz --delete --exclude 'node_modules' --exclude 'dist' --exclude '.git' --exclude 'src' \
           -e "ssh -o StrictHostKeyChecking=no" \
           ./backend/ ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:~/backend/
-          # Copy the generated deploy env file as well
-          rsync -avz -e "ssh -o StrictHostKeyChecking=no" ./.deploy.env ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:~/backend/.deploy.env
+          # Copy the generated deploy env file as well (created in backend step)
+          rsync -avz -e "ssh -o StrictHostKeyChecking=no" ./backend/.deploy.env ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:~/backend/.deploy.env
 
       - name: EC2'da masofaviy buyruqlarni bajarish
         uses: appleboy/ssh-action@master


### PR DESCRIPTION
Fix rsync source path: use backend/.deploy.env (file is created during ECR build step).