### PR TITLE
feat: Add confirmation dialog and optimistic updates for book returns

### DIFF
--- a/frontend/src/components/common/ConfirmationDialog.tsx
+++ b/frontend/src/components/common/ConfirmationDialog.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from "@mui/material";
+
+interface ConfirmationDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  confirmText?: string;
+  cancelText?: string;
+  confirmColor?: "primary" | "error" | "success" | "warning" | "info";
+}
+
+const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
+  open,
+  title,
+  message,
+  onConfirm,
+  onCancel,
+  confirmText = "Tasdiqlash",
+  cancelText = "Bekor qilish",
+  confirmColor = "primary",
+}) => {
+  return (
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      aria-labelledby="confirmation-dialog-title"
+      aria-describedby="confirmation-dialog-description"
+      PaperProps={{
+        sx: {
+          minWidth: 400,
+          borderRadius: 2,
+        },
+      }}
+    >
+      <DialogTitle id="confirmation-dialog-title" sx={{ pb: 2, pt: 3 }}>
+        {title}
+      </DialogTitle>
+      <DialogContent sx={{ pb: 2 }}>
+        <DialogContentText id="confirmation-dialog-description">
+          {message}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 3, pt: 2, gap: 1 }}>
+        <Button
+          onClick={onCancel}
+          color="error"
+          variant="outlined"
+          sx={{ px: 3 }}
+        >
+          {cancelText}
+        </Button>
+        <Button
+          onClick={onConfirm}
+          color={confirmColor}
+          variant="contained"
+          autoFocus
+          sx={{ px: 3 }}
+        >
+          {confirmText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmationDialog;


### PR DESCRIPTION
## 🎯 Changes

This PR adds a better UX for book returns in the All Loans page:

### ✨ Features
- **Confirmation Modal**: Shows a dialog before processing book returns
- **Optimistic Updates**: Book disappears immediately from the list
- **Cancellable Toast**: 5-second countdown with undo button
- **Better Styling**: Improved button colors and spacing

### 🎨 UI Improvements
- Confirmation dialog with proper padding and spacing
- Error-styled cancel button (red outline) in modal
- Warning-colored undo button in toast (orange)
- Responsive toast layout with min-width

### �� User Flow
1. Click "Qaytarish" → Confirmation dialog opens
2. Confirm → Book disappears, cancellable toast appears for 5 seconds
3. User can click "Bekor qilish" to undo
4. After 5 seconds → Return is processed automatically

### 📁 Files Changed
- Created `ConfirmationDialog.tsx` - Reusable confirmation component
- Updated `AllLoansPage.tsx` - Added confirmation and optimistic update logic