### PR TITLE
fix: Correct loan ID type from number to string

### DIFF
--- a/frontend/src/pages/librarian/AllLoansPage.tsx
+++ b/frontend/src/pages/librarian/AllLoansPage.tsx
@@ -57,9 +57,9 @@ const AllLoansPage: React.FC = () => {
   );
   const [confirmDialog, setConfirmDialog] = useState<{
     open: boolean;
-    loanId: number | null;
+    loanId: string | null;
   }>({ open: false, loanId: null });
-  const pendingReturnRef = useRef<{ loanId: number; toastId: string } | null>(null);
+  const pendingReturnRef = useRef<{ loanId: string; toastId: string } | null>(null);
 
   const fetchLoans = useCallback(async () => {
     try {
@@ -97,7 +97,7 @@ const AllLoansPage: React.FC = () => {
     }
   };
 
-  const handleReturnClick = (loanId: number) => {
+  const handleReturnClick = (loanId: string) => {
     setConfirmDialog({ open: true, loanId });
   };
 


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes TypeScript build errors from PR #67

### Issue
- `loan.id` is typed as `string` in the Loan interface
- Functions were expecting `number` type, causing TypeScript errors

### Changes
- Changed `loanId` type from `number` to `string` in confirmDialog state
- Updated `handleReturnClick` parameter type to `string`
- Updated `pendingReturnRef` to use `string` for loanId

### Build Status
✅ TypeScript compilation passes locally