### PR TITLE
fix: delete book copy confirmation not triggering API call

### DIFF
--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -138,7 +138,7 @@ const BookDetailPage: React.FC = () => {
   const handleDeleteClick = () => {
     if (!selectedCopy) return;
     setDeleteConfirmOpen(true);
-    handleMenuClose();
+    setAnchorEl(null);
   };
 
   const handleConfirmDeleteCopy = async () => {


### PR DESCRIPTION
**Bug:** Clicking "Ha, o'chirish" in the delete confirmation dialog did nothing — no API call, no error.

**Root cause:** `handleDeleteClick` called `handleMenuClose()` which set `selectedCopy` to `null` before the confirm dialog could use it.

**Fix:** Replace `handleMenuClose()` with `setAnchorEl(null)` to close the menu while keeping `selectedCopy` intact.